### PR TITLE
Publish REST API docs to rest.galasa.dev

### DIFF
--- a/default/ingress.yaml
+++ b/default/ingress.yaml
@@ -14,6 +14,7 @@ spec:
     - resources.galasa.dev
     - javadoc.galasa.dev
     - javadoc-snapshot.galasa.dev
+    - rest.galasa.dev
     - nexus.galasa.dev
     - docker.galasa.dev
     - development.galasa.dev
@@ -85,6 +86,16 @@ spec:
       - backend:
           service:
             name: resources
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  - host: rest.galasa.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: restapidoc-stable
             port:
               number: 80
         path: /

--- a/default/restapidoc-stable-service.yaml
+++ b/default/restapidoc-stable-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: restapidoc-stable
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    app: restapidoc-stable

--- a/default/restapidoc-stable.yaml
+++ b/default/restapidoc-stable.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: restapidoc-stable
-        image: icr.io/galasadev/galasa-restapidoc-amd64:0.27.0
+        image: icr.io/galasadev/galasa-restapidoc-amd64:0.26.0
         ports:
         - containerPort: 80
       affinity:

--- a/default/restapidoc-stable.yaml
+++ b/default/restapidoc-stable.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: restapidoc-stable
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: restapidoc-stable
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: restapidoc-stable
+    spec:
+      containers:
+      - name: restapidoc-stable
+        image: icr.io/galasadev/galasa-restapidoc-amd64:0.27.0
+        ports:
+        - containerPort: 80
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - restapidoc-stable
+              topologyKey: kubernetes.io/hostname
+


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1406

Note: Merge this PR once the `icr.io/galasadev/galasa-restapidoc-amd64:0.26.0` image has been pushed as it does not currently exist.